### PR TITLE
Salva dados do usuário no localstorage

### DIFF
--- a/src/AuthenticationProvider.js
+++ b/src/AuthenticationProvider.js
@@ -14,10 +14,21 @@ const AuthenticationProvider = ({ children }) => {
     firebase.auth().onAuthStateChanged((authUser) => {
       setLookingForUser(false);
       setAuthUser(authUser);
+
+      if (!authUser) {
+        window.localStorage.removeItem('userData');
+      }
     });
   }, []);
 
   useEffect(() => {
+    const localUserData = window.localStorage.getItem('userData');
+
+    if (localUserData) {
+      setUserData(JSON.parse(localUserData));
+      return;
+    }
+
     if (!authUser) {
       setUserData(null);
       return;
@@ -28,6 +39,10 @@ const AuthenticationProvider = ({ children }) => {
     if (signUpFormUserData) {
       setUserData(signUpFormUserData);
       setLookingForUser(false);
+      window.localStorage.setItem(
+        'userData',
+        JSON.stringify(signUpFormUserData),
+      );
       return;
     }
 
@@ -41,6 +56,8 @@ const AuthenticationProvider = ({ children }) => {
 
         setUserData(storedUserData);
         setLookingForUser(false);
+
+        window.localStorage.setItem('userData', JSON.stringify(storedUserData));
       });
   }, [authUser, signUpFormUserData]);
 


### PR DESCRIPTION
## Verificações

Assinale as verificações abaixo:

* [x] Eu li e segui o [Guia de Contribuição](https://github.com/Minhacps/votacidade/blob/master/.github/CONTRIBUTING.md).
* [x] Eu li e segui o [Código de Conduta](https://github.com/Minhacps/votacidade/blob/master/.github/CODE_OF_CONDUCT.md).
* [x] Eu confirmei que não há outra [Pull Request](https://github.com/Minhacps/votacidade/pulls) para a mesma alteração.

![image](https://user-images.githubusercontent.com/4250355/95534868-ac486400-0a32-11eb-933b-73387101d540.png)

No último dia tivemos 504 escritas e 11k leituras no firestore de autenticação, tivemos muitos novos usuários e isso explica o grande número de gravações.
As mudanças desse PR tem o objetivo de reduzir as leituras considerando que não alteramos os dados de um usuário depois do cadastro. Usando o localstorage não precisamos buscar no firestore, isso nos ecomiza uma leitura e agiliza o carregamento do app.
