### PR TITLE
Melhoria nos testes da página de Ranking

### DIFF
--- a/src/pages/Ranking/Ranking.js
+++ b/src/pages/Ranking/Ranking.js
@@ -133,7 +133,10 @@ export default function Ranking() {
                 </AffinityTag>
               </CardInfo>
             </InfoWrapper>
-            <ProfileLink to={`${cityPath}/perfil/${candidate.id}`}>
+            <ProfileLink
+              to={`${cityPath}/perfil/${candidate.id}`}
+              aria-label={`Ver o perfil do(a) ${candidate.name}`}
+            >
               <FindSvg />
             </ProfileLink>
           </CandidateCard>

--- a/src/pages/Ranking/Ranking.test.js
+++ b/src/pages/Ranking/Ranking.test.js
@@ -1,9 +1,11 @@
 import React, { useContext } from 'react';
 import Ranking from './Ranking';
 import { render, screen } from '@testing-library/react';
-import { BrowserRouter } from 'react-router-dom';
-import userEvent from '@testing-library/user-event';
+import { Router } from 'react-router-dom';
+import user from '@testing-library/user-event';
 import { act } from 'react-dom/test-utils';
+import { createBrowserHistory } from 'history';
+
 import AnswersProvider from 'components/AnswersProvider/AnswersProvider';
 import questionsService from 'components/AnswersProvider/answersService';
 import CityProvider, {
@@ -18,40 +20,55 @@ const mockedCandidates = new Array(30).fill(undefined).map((_, index) => ({
   name: `${candidateNamePrefix}${index}`,
   candidateNumber: 12341229 + index,
   match: `${index}`,
+  politicalParty: `ABC-${index}`,
 }));
-
-jest.spyOn(matchesService, 'getMatches').mockResolvedValue(mockedCandidates);
-
-jest.mock('components/CityProvider/CityProvider');
 
 const mockedAnswers = new Array(30).fill(undefined).reduce((acc, _, index) => {
   acc[index] = { answer: `DT-${index}` };
   return acc;
 }, {});
 
-jest
+const mockedMatchesService = jest
+  .spyOn(matchesService, 'getMatches')
+  .mockResolvedValue(mockedCandidates);
+const mockedQuestionService = jest
   .spyOn(questionsService, 'getAnsweredQuestions')
   .mockResolvedValue(mockedAnswers);
 
-const WrappedUi = () => {
-  const { firebase } = useContext(CityContext);
-
-  return (
-    <BrowserRouter>
-      <AnswersProvider>
-        <MatchesProvider firebase={firebase}>
-          <Ranking />
-        </MatchesProvider>
-      </AnswersProvider>
-    </BrowserRouter>
-  );
-};
-
 jest.useFakeTimers();
+jest.mock('components/CityProvider/CityProvider');
+
+afterAll(() => {
+  jest.unmock('components/CityProvider/CityProvider');
+  mockedMatchesService.mockRestore();
+  mockedQuestionService.mockRestore();
+});
+
+function customRender() {
+  const history = createBrowserHistory();
+  const WrappedUi = () => {
+    const { firebase } = useContext(CityContext);
+
+    return (
+      <Router history={history}>
+        <AnswersProvider>
+          <MatchesProvider firebase={firebase}>
+            <Ranking />
+          </MatchesProvider>
+        </AnswersProvider>
+      </Router>
+    );
+  };
+
+  return {
+    ...render(<WrappedUi />, { wrapper: CityProvider }),
+    history,
+  };
+}
 
 describe('Ranking', () => {
   it('shoud list 10 candidates at a time', async () => {
-    render(<WrappedUi />, { wrapper: CityProvider });
+    customRender();
     const candidatesBatchLength = 10;
 
     async function assertNumberOfCandidates(expectedLenght, total) {
@@ -75,7 +92,7 @@ describe('Ranking', () => {
     });
 
     act(() => {
-      userEvent.click(loadMorebutton);
+      user.click(loadMorebutton);
       jest.runOnlyPendingTimers();
     });
 
@@ -85,13 +102,36 @@ describe('Ranking', () => {
     );
 
     act(() => {
-      userEvent.click(loadMorebutton);
+      user.click(loadMorebutton);
       jest.runOnlyPendingTimers();
     });
 
     await assertNumberOfCandidates(
       candidatesBatchLength * 3,
       mockedCandidates.length,
+    );
+  });
+
+  it('should render a candidates and navigate to candidate profile', async () => {
+    const { history } = customRender();
+
+    const firstCandidate = mockedCandidates[0];
+
+    expect(await screen.findByText(firstCandidate.name)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        `${firstCandidate.candidateNumber} | ${firstCandidate.politicalParty}`,
+      ),
+    ).toBeInTheDocument();
+
+    const profileLink = screen.getByRole('link', {
+      name: `Ver o perfil do(a) ${firstCandidate.name}`,
+    });
+
+    user.click(profileLink);
+
+    expect(history.location.pathname).toContain(
+      `/fake-city/perfil/${firstCandidate.id}`,
     );
   });
 });

--- a/src/pages/Ranking/Ranking.test.js
+++ b/src/pages/Ranking/Ranking.test.js
@@ -13,6 +13,7 @@ import CityProvider, {
 } from 'components/CityProvider/CityProvider';
 import MatchesProvider from 'components/MatchesProvider/MatchesProvider';
 import * as matchesService from 'components/MatchesProvider/matchesService';
+import { cityPath } from 'tests/fakeCity';
 
 const candidateNamePrefix = 'Nome de exemplo #';
 const mockedCandidates = new Array(30).fill(undefined).map((_, index) => ({
@@ -131,7 +132,7 @@ describe('Ranking', () => {
     user.click(profileLink);
 
     expect(history.location.pathname).toContain(
-      `/fake-city/perfil/${firstCandidate.id}`,
+      `${cityPath}/perfil/${firstCandidate.id}`,
     );
   });
 });


### PR DESCRIPTION
## O que

Refatorei o teste de ranking
- Adicionando um customRender exportanto o history possibilitando asserções de navegação
- Restaurando os mocks após o teste
- Utilizando uma asserção no nome dos candidatos ao invés do `test-id`
- Adicionei um teste se as informações do primeiro candidato renderizavam corretamente e se era possível navegar para o perfil do mesmo

## Verificações

Assinale as verificações abaixo:

* [x] Eu li e segui o [Guia de Contribuição](https://github.com/Minhacps/votacidade/blob/master/.github/CONTRIBUTING.md).
* [x] Eu li e segui o [Código de Conduta](https://github.com/Minhacps/votacidade/blob/master/.github/CODE_OF_CONDUCT.md).
* [x] Eu confirmei que não há outra [Pull Request](https://github.com/Minhacps/votacidade/pulls) para a mesma alteração.
