### PR TITLE
Sincroniza firestore a cada 5 respostas

### DIFF
--- a/src/components/AnswersProvider/AnswersProvider.js
+++ b/src/components/AnswersProvider/AnswersProvider.js
@@ -3,9 +3,18 @@ import questionsService from './answersService';
 
 export const AnswersContext = React.createContext();
 
-const AnswersProvider = ({ firebase, currentUser, user, children }) => {
+const answersToCollectBeforeSync = 5;
+
+const AnswersProvider = ({
+  firebase,
+  currentUser,
+  user,
+  children,
+  questionnaire,
+}) => {
   const [answers, setAnswers] = useState({});
   const [isLoading, setIsLoading] = useState(true);
+  const [answersOutOfSync, setAnswersOutOfSync] = useState(0);
 
   useEffect(() => {
     questionsService
@@ -20,10 +29,26 @@ const AnswersProvider = ({ firebase, currentUser, user, children }) => {
   }, []);
 
   const updateAnswers = (newAnswer) => {
-    setAnswers({
+    const answersCounter = answersOutOfSync + 1;
+    const updatedAnswers = {
       ...answers,
       ...newAnswer,
-    });
+    };
+    const isLastQuestion =
+      Object.keys(updatedAnswers).length === questionnaire.length;
+
+    setAnswers(updatedAnswers);
+    setAnswersOutOfSync(answersCounter);
+
+    if (isLastQuestion || answersCounter === answersToCollectBeforeSync) {
+      questionsService.syncAnswers({
+        firebase,
+        currentUser,
+        user,
+        answers: updatedAnswers,
+      });
+      setAnswersOutOfSync(0);
+    }
   };
 
   const getAnswersMap = () =>

--- a/src/components/AnswersProvider/AnswersProvider.test.js
+++ b/src/components/AnswersProvider/AnswersProvider.test.js
@@ -45,11 +45,11 @@ describe('QuestionsProvider', () => {
   beforeEach(() => {
     jest
       .spyOn(questionsService, 'getAnsweredQuestions')
-      .mockImplementation(() => Promise.resolve(storedAnswers));
+      .mockResolvedValue(storedAnswers);
 
     jest
       .spyOn(questionsService, 'syncAnswers')
-      .mockImplementation(() => Promise.resolve());
+      .mockResolvedValue();
 
     jest.clearAllMocks();
   });

--- a/src/components/AnswersProvider/AnswersProvider.test.js
+++ b/src/components/AnswersProvider/AnswersProvider.test.js
@@ -3,7 +3,7 @@ import { render, fireEvent, screen } from '@testing-library/react';
 import AnswersProvider, { AnswersContext } from './AnswersProvider';
 import questionsService from './answersService';
 
-const props = {
+const defaultProps = {
   firebase: {},
   currentUser: { uid: '1' },
   user: { role: 'voter' },
@@ -25,7 +25,7 @@ const props = {
 };
 
 const DataBroadcast = ({ onClick, newAnswer }) => (
-  <AnswersProvider {...props}>
+  <AnswersProvider {...defaultProps}>
     <AnswersContext.Consumer>
       {({ answers, updateAnswers }) => (
         <>
@@ -47,9 +47,7 @@ describe('QuestionsProvider', () => {
       .spyOn(questionsService, 'getAnsweredQuestions')
       .mockResolvedValue(storedAnswers);
 
-    jest
-      .spyOn(questionsService, 'syncAnswers')
-      .mockResolvedValue();
+    jest.spyOn(questionsService, 'syncAnswers').mockResolvedValue();
 
     jest.clearAllMocks();
   });
@@ -81,134 +79,93 @@ describe('QuestionsProvider', () => {
     expect(mockedOnClick).toHaveBeenCalledWith(expectedState);
   });
 
-  it('synchronize the list of answers in batch', async () => {
-    render(
-      <AnswersProvider {...props}>
-        <AnswersContext.Consumer>
-          {({ answers, updateAnswers }) => (
-            <>
-              <button
-                onClick={() =>
-                  updateAnswers({
-                    [Object.keys(answers).length]: { answer: 'DT' },
-                  })
-                }
-              >
-                Add answer
-              </button>
-            </>
-          )}
-        </AnswersContext.Consumer>
-      </AnswersProvider>,
-    );
+  describe('Batch updates', () => {
+    const customRender = (customProps) =>
+      render(
+        <AnswersProvider {...defaultProps} {...customProps}>
+          <AnswersContext.Consumer>
+            {({ answers, updateAnswers }) => (
+              <>
+                <button
+                  onClick={() =>
+                    updateAnswers({
+                      [Object.keys(answers).length]: { answer: 'DT' },
+                    })
+                  }
+                >
+                  Add answer
+                </button>
+              </>
+            )}
+          </AnswersContext.Consumer>
+        </AnswersProvider>,
+      );
 
-    const addAnswerButton = await screen.findByRole('button', {
-      name: 'Add answer',
+    it('should synchronize answers once the user reaches the limit of 5 new answers', async () => {
+      customRender();
+
+      const addAnswerButton = await screen.findByRole('button', {
+        name: 'Add answer',
+      });
+
+      for (let i = 0; i < 10; i++) {
+        fireEvent.click(addAnswerButton);
+      }
+
+      const expectedParams = {
+        firebase: defaultProps.firebase,
+        user: defaultProps.user,
+        currentUser: defaultProps.currentUser,
+        answers: {
+          ...storedAnswers,
+          2: { answer: 'DT' },
+          3: { answer: 'DT' },
+          4: { answer: 'DT' },
+          5: { answer: 'DT' },
+          6: { answer: 'DT' },
+        },
+      };
+
+      expect(questionsService.syncAnswers).toBeCalledTimes(2);
+      expect(questionsService.syncAnswers).toHaveBeenNthCalledWith(
+        1,
+        expectedParams,
+      );
+      expect(questionsService.syncAnswers).toHaveBeenNthCalledWith(2, {
+        ...expectedParams,
+        answers: {
+          ...expectedParams.answers,
+          7: { answer: 'DT' },
+          8: { answer: 'DT' },
+          9: { answer: 'DT' },
+          10: { answer: 'DT' },
+          11: { answer: 'DT' },
+        },
+      });
     });
 
-    fireEvent.click(addAnswerButton);
-    expect(questionsService.syncAnswers).not.toBeCalled();
+    it('should synchronize answers once the user finishes the questionnaire', async () => {
+      customRender({ questionnaire: defaultProps.questionnaire.slice(0, 4) });
 
-    fireEvent.click(addAnswerButton);
-    expect(questionsService.syncAnswers).not.toBeCalled();
+      const addAnswerButton = await screen.findByRole('button', {
+        name: 'Add answer',
+      });
 
-    fireEvent.click(addAnswerButton);
-    expect(questionsService.syncAnswers).not.toBeCalled();
+      fireEvent.click(addAnswerButton);
+      expect(questionsService.syncAnswers).not.toBeCalled();
 
-    fireEvent.click(addAnswerButton);
-    expect(questionsService.syncAnswers).not.toBeCalled();
-
-    fireEvent.click(addAnswerButton);
-    expect(questionsService.syncAnswers).toBeCalledWith({
-      firebase: props.firebase,
-      user: props.user,
-      currentUser: props.currentUser,
-      answers: {
-        ...storedAnswers,
-        2: { answer: 'DT' },
-        3: { answer: 'DT' },
-        4: { answer: 'DT' },
-        5: { answer: 'DT' },
-        6: { answer: 'DT' },
-      },
-    });
-
-    questionsService.syncAnswers.mockClear();
-
-    fireEvent.click(addAnswerButton);
-    expect(questionsService.syncAnswers).not.toBeCalled();
-
-    fireEvent.click(addAnswerButton);
-    expect(questionsService.syncAnswers).not.toBeCalled();
-
-    fireEvent.click(addAnswerButton);
-    expect(questionsService.syncAnswers).not.toBeCalled();
-
-    fireEvent.click(addAnswerButton);
-    expect(questionsService.syncAnswers).not.toBeCalled();
-
-    fireEvent.click(addAnswerButton);
-    expect(questionsService.syncAnswers).toBeCalledWith({
-      firebase: props.firebase,
-      user: props.user,
-      currentUser: props.currentUser,
-      answers: {
-        ...storedAnswers,
-        2: { answer: 'DT' },
-        3: { answer: 'DT' },
-        4: { answer: 'DT' },
-        5: { answer: 'DT' },
-        6: { answer: 'DT' },
-        7: { answer: 'DT' },
-        8: { answer: 'DT' },
-        9: { answer: 'DT' },
-        10: { answer: 'DT' },
-        11: { answer: 'DT' },
-      },
-    });
-  });
-
-  it('synchronize answers when it is the last one', async () => {
-    render(
-      <AnswersProvider
-        {...props}
-        questionnaire={props.questionnaire.slice(0, 4)}
-      >
-        <AnswersContext.Consumer>
-          {({ answers, updateAnswers }) => (
-            <>
-              <button
-                onClick={() =>
-                  updateAnswers({
-                    [Object.keys(answers).length]: { answer: 'DT' },
-                  })
-                }
-              >
-                Add answer
-              </button>
-            </>
-          )}
-        </AnswersContext.Consumer>
-      </AnswersProvider>,
-    );
-
-    const addAnswerButton = await screen.findByRole('button', {
-      name: 'Add answer',
-    });
-
-    fireEvent.click(addAnswerButton);
-    expect(questionsService.syncAnswers).not.toBeCalled();
-
-    fireEvent.click(addAnswerButton);
-    expect(questionsService.syncAnswers).toBeCalledWith({
-      firebase: props.firebase,
-      user: props.user,
-      currentUser: props.currentUser,
-      answers: {
-        ...storedAnswers,
-        2: { answer: 'DT' },
-        3: { answer: 'DT' },
-      },
+      fireEvent.click(addAnswerButton);
+      expect(questionsService.syncAnswers).toBeCalledTimes(1);
+      expect(questionsService.syncAnswers).toBeCalledWith({
+        firebase: defaultProps.firebase,
+        user: defaultProps.user,
+        currentUser: defaultProps.currentUser,
+        answers: {
+          ...storedAnswers,
+          2: { answer: 'DT' },
+          3: { answer: 'DT' },
+        },
+      });
     });
   });
 });

--- a/src/components/AnswersProvider/AnswersProvider.test.js
+++ b/src/components/AnswersProvider/AnswersProvider.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render, fireEvent, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import AnswersProvider, { AnswersContext } from './AnswersProvider';
 import questionsService from './answersService';
 
@@ -56,7 +57,7 @@ describe('QuestionsProvider', () => {
     const mockedOnClick = jest.fn();
     render(<DataBroadcast onClick={mockedOnClick} />);
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Get answers' }));
+    userEvent.click(await screen.findByRole('button', { name: 'Get answers' }));
 
     expect(mockedOnClick).toHaveBeenCalledWith(storedAnswers);
   });
@@ -66,10 +67,10 @@ describe('QuestionsProvider', () => {
     const mockedOnClick = jest.fn();
     render(<DataBroadcast onClick={mockedOnClick} newAnswer={newAnswer} />);
 
-    fireEvent.click(
+    userEvent.click(
       await screen.findByRole('button', { name: 'Update answers' }),
     );
-    fireEvent.click(await screen.findByRole('button', { name: 'Get answers' }));
+    userEvent.click(await screen.findByRole('button', { name: 'Get answers' }));
 
     const expectedState = {
       ...storedAnswers,
@@ -109,7 +110,7 @@ describe('QuestionsProvider', () => {
       });
 
       for (let i = 0; i < 10; i++) {
-        fireEvent.click(addAnswerButton);
+        userEvent.click(addAnswerButton);
       }
 
       const expectedParams = {
@@ -151,10 +152,10 @@ describe('QuestionsProvider', () => {
         name: 'Add answer',
       });
 
-      fireEvent.click(addAnswerButton);
+      userEvent.click(addAnswerButton);
       expect(questionsService.syncAnswers).not.toBeCalled();
 
-      fireEvent.click(addAnswerButton);
+      userEvent.click(addAnswerButton);
       expect(questionsService.syncAnswers).toBeCalledTimes(1);
       expect(questionsService.syncAnswers).toBeCalledWith({
         firebase: defaultProps.firebase,

--- a/src/components/AnswersProvider/AnswersProvider.test.js
+++ b/src/components/AnswersProvider/AnswersProvider.test.js
@@ -3,8 +3,29 @@ import { render, fireEvent, screen } from '@testing-library/react';
 import AnswersProvider, { AnswersContext } from './AnswersProvider';
 import questionsService from './answersService';
 
+const props = {
+  firebase: {},
+  currentUser: { uid: '1' },
+  user: { role: 'voter' },
+  questionnaire: [
+    { question: 'q1' },
+    { question: 'q2' },
+    { question: 'q3' },
+    { question: 'q4' },
+    { question: 'q5' },
+    { question: 'q6' },
+    { question: 'q7' },
+    { question: 'q8' },
+    { question: 'q9' },
+    { question: 'q10' },
+    { question: 'q11' },
+    { question: 'q12' },
+    { question: 'q13' },
+  ],
+};
+
 const DataBroadcast = ({ onClick, newAnswer }) => (
-  <AnswersProvider>
+  <AnswersProvider {...props}>
     <AnswersContext.Consumer>
       {({ answers, updateAnswers }) => (
         <>
@@ -17,14 +38,22 @@ const DataBroadcast = ({ onClick, newAnswer }) => (
     </AnswersContext.Consumer>
   </AnswersProvider>
 );
+
 const storedAnswers = { 0: { answer: 'DT' }, 1: { answer: 'CT' } };
-beforeEach(() => {
-  jest
-    .spyOn(questionsService, 'getAnsweredQuestions')
-    .mockImplementation(() => Promise.resolve(storedAnswers));
-});
 
 describe('QuestionsProvider', () => {
+  beforeEach(() => {
+    jest
+      .spyOn(questionsService, 'getAnsweredQuestions')
+      .mockImplementation(() => Promise.resolve(storedAnswers));
+
+    jest
+      .spyOn(questionsService, 'syncAnswers')
+      .mockImplementation(() => Promise.resolve());
+
+    jest.clearAllMocks();
+  });
+
   it('should return all stored questions', async () => {
     const mockedOnClick = jest.fn();
     render(<DataBroadcast onClick={mockedOnClick} />);
@@ -50,5 +79,136 @@ describe('QuestionsProvider', () => {
     };
 
     expect(mockedOnClick).toHaveBeenCalledWith(expectedState);
+  });
+
+  it('synchronize the list of answers in batch', async () => {
+    render(
+      <AnswersProvider {...props}>
+        <AnswersContext.Consumer>
+          {({ answers, updateAnswers }) => (
+            <>
+              <button
+                onClick={() =>
+                  updateAnswers({
+                    [Object.keys(answers).length]: { answer: 'DT' },
+                  })
+                }
+              >
+                Add answer
+              </button>
+            </>
+          )}
+        </AnswersContext.Consumer>
+      </AnswersProvider>,
+    );
+
+    const addAnswerButton = await screen.findByRole('button', {
+      name: 'Add answer',
+    });
+
+    fireEvent.click(addAnswerButton);
+    expect(questionsService.syncAnswers).not.toBeCalled();
+
+    fireEvent.click(addAnswerButton);
+    expect(questionsService.syncAnswers).not.toBeCalled();
+
+    fireEvent.click(addAnswerButton);
+    expect(questionsService.syncAnswers).not.toBeCalled();
+
+    fireEvent.click(addAnswerButton);
+    expect(questionsService.syncAnswers).not.toBeCalled();
+
+    fireEvent.click(addAnswerButton);
+    expect(questionsService.syncAnswers).toBeCalledWith({
+      firebase: props.firebase,
+      user: props.user,
+      currentUser: props.currentUser,
+      answers: {
+        ...storedAnswers,
+        2: { answer: 'DT' },
+        3: { answer: 'DT' },
+        4: { answer: 'DT' },
+        5: { answer: 'DT' },
+        6: { answer: 'DT' },
+      },
+    });
+
+    questionsService.syncAnswers.mockClear();
+
+    fireEvent.click(addAnswerButton);
+    expect(questionsService.syncAnswers).not.toBeCalled();
+
+    fireEvent.click(addAnswerButton);
+    expect(questionsService.syncAnswers).not.toBeCalled();
+
+    fireEvent.click(addAnswerButton);
+    expect(questionsService.syncAnswers).not.toBeCalled();
+
+    fireEvent.click(addAnswerButton);
+    expect(questionsService.syncAnswers).not.toBeCalled();
+
+    fireEvent.click(addAnswerButton);
+    expect(questionsService.syncAnswers).toBeCalledWith({
+      firebase: props.firebase,
+      user: props.user,
+      currentUser: props.currentUser,
+      answers: {
+        ...storedAnswers,
+        2: { answer: 'DT' },
+        3: { answer: 'DT' },
+        4: { answer: 'DT' },
+        5: { answer: 'DT' },
+        6: { answer: 'DT' },
+        7: { answer: 'DT' },
+        8: { answer: 'DT' },
+        9: { answer: 'DT' },
+        10: { answer: 'DT' },
+        11: { answer: 'DT' },
+      },
+    });
+  });
+
+  it('synchronize answers when it is the last one', async () => {
+    render(
+      <AnswersProvider
+        {...props}
+        questionnaire={props.questionnaire.slice(0, 4)}
+      >
+        <AnswersContext.Consumer>
+          {({ answers, updateAnswers }) => (
+            <>
+              <button
+                onClick={() =>
+                  updateAnswers({
+                    [Object.keys(answers).length]: { answer: 'DT' },
+                  })
+                }
+              >
+                Add answer
+              </button>
+            </>
+          )}
+        </AnswersContext.Consumer>
+      </AnswersProvider>,
+    );
+
+    const addAnswerButton = await screen.findByRole('button', {
+      name: 'Add answer',
+    });
+
+    fireEvent.click(addAnswerButton);
+    expect(questionsService.syncAnswers).not.toBeCalled();
+
+    fireEvent.click(addAnswerButton);
+    expect(questionsService.syncAnswers).toBeCalledWith({
+      firebase: props.firebase,
+      user: props.user,
+      currentUser: props.currentUser,
+      answers: {
+        ...storedAnswers,
+        2: { answer: 'DT' },
+        3: { answer: 'DT' },
+      },
+    });
   });
 });

--- a/src/components/AnswersProvider/answersService.js
+++ b/src/components/AnswersProvider/answersService.js
@@ -13,6 +13,14 @@ export const getAnsweredQuestions = ({ firebase, user, currentUser }) =>
       }
     });
 
+export const syncAnswers = ({ firebase, user, currentUser, answers }) =>
+  firebase
+    .firestore()
+    .collection(answersCollection(user.role))
+    .doc(currentUser.uid)
+    .set(answers, { merge: true });
+
 export default {
   getAnsweredQuestions,
+  syncAnswers,
 };

--- a/src/components/Question/Question.js
+++ b/src/components/Question/Question.js
@@ -1,10 +1,8 @@
-import React, { useState, useContext } from 'react';
+import React, { useContext, useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import { Form, Alert, Label, FormText, FormGroup } from 'reactstrap';
+import { Alert, Form, FormGroup, FormText, Label } from 'reactstrap';
 
 import { ROLE_CANDIDATE } from 'constants/userRoles';
-
-import { answersCollection } from 'constants/firestoreCollections';
 import { CityContext } from 'components/CityProvider/CityProvider';
 import { AnswersContext } from '../AnswersProvider/AnswersProvider';
 
@@ -47,12 +45,6 @@ const Question = ({
     const currentAnswersSize = Object.keys(allAnswers).length;
 
     updateAnswers(answer);
-
-    firebase
-      .firestore()
-      .collection(answersCollection(user.role))
-      .doc(currentUser.uid)
-      .set(answer, { merge: true });
 
     // Last question.
     const candidateCondition =


### PR DESCRIPTION
## Verificações

Assinale as verificações abaixo:

* [x] Eu li e segui o [Guia de Contribuição](https://github.com/Minhacps/votacidade/blob/master/.github/CONTRIBUTING.md).
* [x] Eu li e segui o [Código de Conduta](https://github.com/Minhacps/votacidade/blob/master/.github/CODE_OF_CONDUCT.md).
* [x] Eu confirmei que não há outra [Pull Request](https://github.com/Minhacps/votacidade/pulls) para a mesma alteração.

## O que foi alterado

Anteriormente estávamos chamando o firestore no componente Question, agora usamos a função `updateAnswers` do `AnswersProvider` para fazer isso.
No provider temos um acumulador que é incrementado depois de cada resposta e sincroniza os dados com o firestore a cada 5 respostas ou caso seja a última resposta.

O objetivo desse PR é otimizar número de escritas que fazemso no firestore, não importa o tamanho do objeto que estamos escrevendo e sim quantas vezes. Por isso agora sempre sincronizamos todas as respostas e o firestore cuida de fazer o diff e sobrescrever apenas o necessário.
Optei por não usar o localstorage nessa primeira implementação para fazer o mais simples possível e incrementar o que for necessário depois.

Resolves #132 
Resolves #147 