### PR TITLE
Remove candidatos com respostas nulas

### DIFF
--- a/server/getTopMatches/getTopMatches.js
+++ b/server/getTopMatches/getTopMatches.js
@@ -23,7 +23,7 @@ const getMatchScores = (voterAnswers, allCandidatesData) => {
     .reduce((matches, candidateId) => {
       const { answers, ...candidateProfile } = allCandidatesData[candidateId];
 
-      if (!answers || answers.length !== 30) {
+      if (!answers || answers.length !== 30 || answers.includes(null)) {
         return matches;
       }
 

--- a/server/getTopMatches/getTopMatches.test.js
+++ b/server/getTopMatches/getTopMatches.test.js
@@ -89,4 +89,23 @@ describe('getTopMatches', () => {
     expect(result[0].id).toEqual('candidate-2');
     expect(result[1].id).toEqual('candidate-1');
   });
+
+  it('removes null values from the answers list', async () => {
+    const fakeDatabaseData = {
+      'candidate-1': {
+        ...candidateData,
+        answers: [null, ...Array(29).fill('CT')],
+      },
+      'candidate-2': {
+        ...candidateData,
+        answers: Array(30).fill('DT'),
+      },
+    };
+
+    mockCandidateAnswers(fakeDatabaseData);
+
+    const result = await getTopMatches(instanceName, voterAnswers);
+
+    expect(result.length).toBe(1);
+  });
 });


### PR DESCRIPTION
## Verificações

Assinale as verificações abaixo:

* [x] Eu li e segui o [Guia de Contribuição](https://github.com/Minhacps/votacidade/blob/master/.github/CONTRIBUTING.md).
* [x] Eu li e segui o [Código de Conduta](https://github.com/Minhacps/votacidade/blob/master/.github/CODE_OF_CONDUCT.md).
* [x] Eu confirmei que não há outra [Pull Request](https://github.com/Minhacps/votacidade/pulls) para a mesma alteração.

Recebemos um feedback avisando que estávamos mostrando um resultado errado no ranking, isso aconteceu pois temos alguns registros no realtime database em que questões puladas ficaram registradas como `null` no array de respostas.